### PR TITLE
Support float precision ops per second

### DIFF
--- a/apply/apply.go
+++ b/apply/apply.go
@@ -21,7 +21,7 @@ import (
 // Note that applyOps is idempotent so it can be run repeatedly. It does
 // this by doing things like converting inserts into upserts. For more details
 // so the applyOp code.
-func ApplyOps(r io.Reader, opsPerSecond int, session *mgo.Session) error {
+func ApplyOps(r io.Reader, opsPerSecond float64, session *mgo.Session) error {
 	log.Printf("Beginning to replay")
 	opScanner := bsonScanner.New(r)
 
@@ -40,7 +40,7 @@ func ApplyOps(r io.Reader, opsPerSecond int, session *mgo.Session) error {
 		}
 
 		millisElapsed := time.Now().Sub(start).Nanoseconds() / (1000 * 1000)
-		expectedMillisElapsed := (float64(numOps) / float64(opsPerSecond)) * 1000
+		expectedMillisElapsed := (float64(numOps) / opsPerSecond) * 1000
 
 		timeToWait := int64(expectedMillisElapsed) - millisElapsed
 		if timeToWait > 0 {

--- a/main.go
+++ b/main.go
@@ -17,7 +17,7 @@ import (
 func main() {
 	mongoURL := flag.String("mongoURL", "localhost", "The mongo database to run the operations against")
 	path := flag.String("path", "", "The path to the json operations to replay")
-	opsPerSecond := flag.Int("speed", 1, "The number of operations to apply per second")
+	opsPerSecond := flag.Float64("speed", 1, "The number of operations to apply per second")
 	flag.Parse()
 
 	session, err := mgo.Dial(*mongoURL)


### PR DESCRIPTION
Since oplog-replay supported this. Also, during exponential backoff we
make the speed slower by dividing by 2, so it's possible we would get to
a non-float value.
