### PR TITLE
Simpler report-card invocation: mongo-op-throttler

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -11,7 +11,7 @@ notify:
 publish:
   catapult:
     url: $$catapult_url
-    application: "mongo-op-throttler"
+    application: mongo-op-throttler
   docker:
     docker_host: $$docker_server
     email: $$docker_email
@@ -23,8 +23,9 @@ publish:
     username: $$docker_username
     when:
       branch: master
+  report_card: {}
 services:
 - clever/mongo:3.0
 script:
-  - make test
-  - make build
+- make test
+- make build


### PR DESCRIPTION
Context:  https://clever.atlassian.net/browse/INFRA-1577

Refactor so that report-card is invoked via a Publish block;
this lets Drone do the heavy-lifting instead of setting it up locally.

Expected changes:
- ADDED
  - A single entry in the "publish" block `report_card: {}` (if this wasn't already present)
- REMOVED
  - All "env" block entries related to report-card are removed
  - All "script" block entries related to report-card are removed
- MODIFIED
  - YAML reformatting/linting (side-effect)

**Please verify by looking at the build logs**
1. Your build ran successfully (all tests and script steps completed)
2. Report card ran successfully (you can see it in the

If you see any errors in the above, please loop @nathanleiby (@n on Slack) into the PR.
Thanks!
