### PR TITLE
Use debian debian in Dockerfile (google/debian is deprecated) 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM google/debian:wheezy
+FROM debian:wheezy
 
 RUN apt-get -y update && apt-get -y install curl
 RUN curl -L https://github.com/Clever/gearcmd/releases/download/0.10.0/gearcmd-v0.10.0-linux-amd64.tar.gz | tar xz -C /usr/local/bin --strip-components 1


### PR DESCRIPTION
The dockerhub repo we used to use for debian (`google/debian`) is deprecated and has not been updated for 2 years: https://hub.docker.com/r/google/debian/.

Though the page at that URL suggests moving to another Google debian,  we should just use the base debian, `debian`. We're already using it in many other repos, and it's less likely to change location in the future because it's maintained by debian vs google.